### PR TITLE
Adds the 10x workshops page to the people tab

### DIFF
--- a/people.md
+++ b/people.md
@@ -14,3 +14,4 @@ description: What we'll do, are doing, have done
 * [ ] AI Engineering
 * [ ] AI Tactics
 * [ ] AI Strategy
+* [ ] [10x Workshops](/people/10x_workshops.html)

--- a/people/10x_workshops.md
+++ b/people/10x_workshops.md
@@ -1,0 +1,19 @@
+# **10x workshops**
+
+### Overview
+This page provides an overview of past and upcoming 10x workshops for 
+
+___
+
+### Upcoming Sessions
+
+**MLOPs** Defining an end-to-end pipeline for continuous integration/deployment/training (CI/CD/CT) including
+monitoring of deployed models.
+
+**Standardisation of datasets** Creating a standard template for composing datasets for use with internal software 
+applications.
+
+___
+
+### Complete Sessions
+N/A


### PR DESCRIPTION
Adds a list of upcoming 10x workshops. Once a workshops is complete a summary can be written and linked to from the complete sessions section.