### PR TITLE
Added project plan to AI008

### DIFF
--- a/projects/AIC008-detection-of-early-rectal-cancers-polyps.md
+++ b/projects/AIC008-detection-of-early-rectal-cancers-polyps.md
@@ -8,7 +8,7 @@ description: What we'll do, are doing, have done
 
 | <b>Project Title</b> | A machine learning algorithm to aid in the detection of early rectal cancers/polyps.  |
 | <b>Clinical lead(s)</b> | Tina Mistry |
-| <b>CSC lead</b> | [Laurence](/team/laurence.html) |
+| <b>CSC lead</b> | [Laurence Jackson](/team.html) |
 | <b>Rationale</b> | Development of an AI tool to identify areas of concern that may indicate early development of cancer and polyps in rectal MRI images |
 | <b>Modality</b> | MRI |
 | <b>Pathology</b> | Rectal cancer/polyps |

--- a/projects/AIC008-detection-of-early-rectal-cancers-polyps.md
+++ b/projects/AIC008-detection-of-early-rectal-cancers-polyps.md
@@ -7,7 +7,7 @@ description: What we'll do, are doing, have done
 # **Early detection of rectal cancer**
 
 | <b>Project Title</b> | A machine learning algorithm to aid in the detection of early rectal cancers/polyps.  |
-| <b>Clinical lead(s)</b> | - |
+| <b>Clinical lead(s)</b> | Tina Mistry |
 | <b>CSC lead</b> | [Laurence](/team/laurence.html) |
 | <b>Rationale</b> | Development of an AI tool to identify areas of concern that may indicate early development of cancer and polyps in rectal MRI images |
 | <b>Modality</b> | MRI |
@@ -19,5 +19,47 @@ description: What we'll do, are doing, have done
 | <b>Goals</b> | An application that is able to identify areas of concern for further analysis by radiologists |
 | <b>Criteria for success</b> | Ability to identify lesions incidentally/early leading to improved outcomes for patients, early detection leads to stopping/reducing the development of malignancy which can be fatal when diagnosed at a late stage. |
 | <b>Commercial products available</b> | None identified |
-| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications <br><br> 2.Setting technical and system requirements for AI model <br><br> 3.Dataset curation (retrospective) <br><br> 4.Model training <br><br> 5.Model testing <br><br> 6.Implementation |
 | <b>References</b> | [1] Lee, Joohyung, et al. "Reducing the model variance of a rectal cancer segmentation network." IEEE Access 7 (2019): 182725-182733. [online](https://arxiv.org/pdf/1901.07213.pdf) |
+
+___
+
+*The plan below aims to outline the expected outcomes for each stage of the project development cycle.*
+### Project Plan
+**Planning phase**
+1. Meeting of all persons involved to determine AI specifications
+    1. Agree project plan
+    2. Setting technical and system requirements for AI model
+    3. Agree on most useful metrics for success – e.g. percentage reduction in missed polyps
+        * step change in number of reported polyps
+        * This will require designing a fixed methodology for measuring currently missed polyps which can be performed before and after model deployment.
+    4. Agree on minimum valuable requirements for success e.g. 25% reduction in missed polyps
+        * We are aiming for a 10% reduction in missed polyps using the methodology above.
+    5. Agree on size of POC and production datasets and who is responsible for compiling them
+        * We will use existing database of 5 year audit to generate proof-of-concept dataset
+    6. Agree on how model will be deployed
+        * The application will push information back to radiologist workstation to indicate suspect dicom series as well as slice number and region
+
+**Development phase (proof of concept (POC))**
+2. Dataset curation (retrospective)
+    1. Compile POC dataset
+3. Model training
+    1. Produce effective POC model
+4. Model testing
+    1. Test model against agreed criteria for success (where applicable)
+    2. Agreement to continue to production phase OR iterative/improve model OR discontinue
+
+**Development phase (production)**
+5. Dataset curation (retrospective)
+    1. Compile larger production dataset with all appropriate data properties (e.g. ethnicity, weight etc)
+6. Model training
+    1. Produce effective deployment model
+7. Model testing
+    1. Test model against agreed criteria for success (where applicable)
+    2. Clinical approval for model to be deployed
+
+**Deployment phase**
+8. Deployment to test environment (if applicable)
+    1. Testing successful
+9. Deployment to hospital systems
+    1. Training for users
+    2. Continuous monitoring of model performance


### PR DESCRIPTION
Adds project plan to rectal polyp project. The plan was a result of the first meeting with Tina to agree on requirements.

Something to note: I found it really difficult to modify the markdown in the existing template. Currently, the project pages are one big markdown table and it can be awkward to add large sections (such as the project plan), since they do not allow newline characters, only <br>'s. The markdown preview in pycharm and atom was also unable to properly preview the table in the same way as it appeared on the served website. For this reason, I've added the project plan section in plain markdown after the table. This seems to be a much more practical way to write in this section and will make it easier in the future to add new details to the plan as they are agreed. 

In this way the table because a sort of quick project overview with more detail in sections below.