### PR TITLE
Blog section added to navbar and current blogs added to the list

### DIFF
--- a/_data/blog.yml
+++ b/_data/blog.yml
@@ -9,8 +9,12 @@
   description: Summary of a 12 weeks placement
   link: blogs/20210825-STP_blog.html
 
+- name: 10x Workshop The Problem of Bias in AI
+  description: |
+    We held a workshop on racial bias in AI and strategies to combat it.
+  link: blogs/20210602-10x-RacialBias.html
+
 - name: 10x Workshop The pathway to integrating AI into NHS practice
   description: |
     Summary of our first workshop as we tackle project process mapping
   link: blogs/20210317-10x-Workshop1.html
-

--- a/_data/blog.yml
+++ b/_data/blog.yml
@@ -1,0 +1,16 @@
+# Add your blog here by filling in the name, description and the link as below. Add your recent blog to the top so it
+# remains in chronological order
+#
+# - name:
+#  description:
+#  link:
+
+- name: NHS STP Bioinformatics Experience
+  description: Summary of a 12 weeks placement
+  link: blogs/20210825-STP_blog.html
+
+- name: 10x Workshop The pathway to integrating AI into NHS practice
+  description: |
+    Summary of our first workshop as we tackle project process mapping
+  link: blogs/20210317-10x-Workshop1.html
+

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -19,6 +19,9 @@
                     <a class="nav-link{% if page.url == '/howto.html' %} active{% endif %}" href="/howto.html">How-to</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link{% if page.url == '/blog.html' %} active{% endif %}" href="/blog.html">Blog</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link{% if page.url == '/reading.html' %} active{% endif %}" href="/reading.html">Reading List</a>
                 </li>
                 <li class="nav-item">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th scope="col">Blog</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for blog in site.data.blog %}
+  <tr>
+    <td>{% if blog.link %}<a href="{{ blog.link }}">{{ blog.name }}</a>{% else %} {{ blog.name }}{% endif %}</td>
+    <td>{{ blog.description }}</td>
+  </tr>
+{% endfor %}
+  </tbody>
+</table>
+
+{{ content }}

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,7 @@
+---
+layout: blog
+title: Blog
+description: Find out what we're working on!
+---
+
+See `_data/blog.yml` to add to this page.


### PR DESCRIPTION
This is far from being an ideal solution but jekyll primer we're using with this bootstrap doesn't let us use jekyll cards as are usually used (normally you'd put your blogs into a folder called _posts and then name them like this: YYYY-MM-DD-name.md but it wont compile for me when I try and google tells me its because github pages dont support jekyll plugins in some themes, including ours). For now the solution is that every new blog needs to be manually added to a blog section in _data/blog (same as any resource). Hopefully we can update the theme in the future and then we can do auto-generation of blog lists. This will do until then.